### PR TITLE
turn off default features on holochain_zome_types

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 serde = "1"
 holo_hash = "0.0.7"
-holochain_zome_types = "0.0.10"
+holochain_zome_types = { version = "0.0.10", default-features = false }
 holochain_serialized_bytes = "0.0.51"
 
 [lib]


### PR DESCRIPTION
this removes the dependency on rusqlite, which neither feasible nor
useful within the context of zomes.