### PR TITLE
Specify Crate Versions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 serde = "1"
 # :DUPE: hdk-rust-revid
-hdi = "0.0"
+hdi = "0.0.19"
 
 [lib]
 path = "src/lib.rs"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 serde = "1"
 # :DUPE: hdk-rust-revid
-hdk = "0.0"
+hdk = "0.0.147"
 holo_hash = "0.0"
 
 hc_zome_dna_auth_resolver_rpc = { path = "../rpc" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 serde = "1"
 holo_hash = "0.0"
-holochain_zome_types = { version = "0.0", default-features = false }
+holochain_zome_types = { version = "0.0.44", default-features = false }
 holochain_serialized_bytes = "0.0"
 
 [lib]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 serde = "1"
-hdk = "0.0"
+hdk = "0.0.147"
 holo_hash = "0.0"
 
 hc_zome_dna_auth_resolver_core = { path = "../core" }

--- a/zome/Cargo.toml
+++ b/zome/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 serde = "1"
 # :DUPE: hdk-rust-revid
-hdk = "0.0"
+hdk = "0.0.147"
 
 hc_zome_dna_auth_resolver_rpc = { path = "../rpc" }
 hc_zome_dna_auth_resolver_storage = { path = "../storage" }


### PR DESCRIPTION
Since we were not being explicit with crate versions (using `0.0` for crates like `hdk`, `hdi` and some others) this would lead to version mismatches in hREA. By specifying the exact version, the mismatch no longer occurs. Perhaps there is a way to coerce this crate to a specific version on the hREA side instead.